### PR TITLE
work around for the TVDB API changes/problems causing crashes

### DIFF
--- a/lib/gatherer.py
+++ b/lib/gatherer.py
@@ -91,9 +91,13 @@ class Gatherer(object):
             for arttype, artlist in providerimages.iteritems():
                 if arttype.startswith('season.'):
                     season = arttype.rsplit('.', 2)[1]
-                    if int(season) not in seasons:
-                        # Don't add artwork for seasons we don't have
+                    try:
+                        if int(season) not in seasons:
+                            # Don't add artwork for seasons we don't have
+                            continue
+                    except ValueError:
                         continue
+
                 if arttype not in images:
                     images[arttype] = []
                 images[arttype].extend(artlist)

--- a/lib/providers/thetvdbv2.py
+++ b/lib/providers/thetvdbv2.py
@@ -86,7 +86,7 @@ class TheTVDBProvider(AbstractImageProvider):
                     else:
                         try:
                             sortsize = int(image['resolution'].split('x')[0 if arttype != 'poster' else 1])
-                        except ValueError:
+                        except (ValueError,IndexError):
                             self.log('whoops, ValueError on "%s"' % image['resolution'])
                             sortsize = 0
                         resultimage['size'] = SortedDisplay(sortsize, image['resolution'])


### PR DESCRIPTION
Looks like the "season" and "image" fields are sometimes empty, now it should just skip those. I don't know if this is an appropriate fix but it works for me so thought I'd share.